### PR TITLE
link: Add function to unset carrier request

### DIFF
--- a/include/netlink/route/link.h
+++ b/include/netlink/route/link.h
@@ -199,6 +199,7 @@ extern int      rtnl_link_get_master(struct rtnl_link *);
 
 extern void     rtnl_link_set_carrier(struct rtnl_link *, uint8_t);
 extern uint8_t  rtnl_link_get_carrier(struct rtnl_link *);
+extern void     rtnl_link_unset_carrier_request_flag(struct rtnl_link *);
 
 extern int      rtnl_link_get_carrier_changes(struct rtnl_link *, uint32_t *);
 

--- a/lib/route/link.c
+++ b/lib/route/link.c
@@ -2434,6 +2434,17 @@ uint8_t rtnl_link_get_carrier(struct rtnl_link *link)
 }
 
 /**
+ * Unset carrier request of link object
+ * @arg link		Link object
+ *
+ * @see rtnl_link_set_carrier()
+ */
+void rtnl_link_unset_carrier_request_flag(struct rtnl_link *link)
+{
+	link->ce_mask &= ~LINK_ATTR_CARRIER;
+}
+
+/**
  * Return carrier on/off changes of link object
  * @arg link		Link object
  * @arg carrier_changes	Pointer to store number of carrier changes

--- a/libnl-route-3.sym
+++ b/libnl-route-3.sym
@@ -1358,4 +1358,5 @@ global:
 	rtnl_interlink_set_net_id;
 	rtnl_flower_set_ip_ttl;
 	rtnl_flower_get_ip_ttl;
+	rtnl_link_unset_carrier_request_flag;
 } libnl_3_6;


### PR DESCRIPTION
When fetching from the kernel this flag seems to be set and when making a change request this persists. Since it's only internal variables we need a function to unset it from the outside.

ndo_carrier_change in the kernel should only be implemented by non-hardware interfaces. For hardware interfaces (e.g. physical ports) it will be EOPNOTSUPP. Allow unsetting it to not get an error.